### PR TITLE
Update ruby version 2.6 -> 3.1

### DIFF
--- a/lib/pipeline-stack.ts
+++ b/lib/pipeline-stack.ts
@@ -97,7 +97,7 @@ export class CodePipelineStack extends Stack {
             phases: {
               install: {
                 'runtime-versions': {
-                  ruby: '2.6'
+                  ruby: '3.1'
                 }
               }
             }


### PR DESCRIPTION
Hello,

While implementing the "AWS CodePipeline with CI/CD practices", I encountered an error during the CodeBuild step, specifically in the PipelineDevSecurity > DOWNLOAD_SOURCE phase. The error message was:

```bash
YAML_FILE_ERROR: Unknown runtime version named '2.6' of ruby. This build image has the following versions: 3.1
```

To address this, I've updated the Ruby version in our configuration. Please review and let me know if there are any further adjustments needed.

Thank you!

